### PR TITLE
Assetto Corsa (#55)

### DIFF
--- a/CrewChiefV4/ACS/ACSData.cs
+++ b/CrewChiefV4/ACS/ACSData.cs
@@ -122,6 +122,7 @@ namespace CrewChiefV4.assetto
             public int drsEnabled;
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
             public float[] brakeTemp;
+            public float clutch;
            
         }
         [StructLayout(LayoutKind.Sequential, Pack = 4, CharSet = CharSet.Unicode)]

--- a/CrewChiefV4/GameState/GameStateData.cs
+++ b/CrewChiefV4/GameState/GameStateData.cs
@@ -623,7 +623,7 @@ namespace CrewChiefV4.GameState
             }
         }
 
-        public OpponentDelta getTimeDifferenceToPlayer(SessionData playerSessionData)
+        public OpponentDelta getTimeDifferenceToPlayer(SessionData playerSessionData, Boolean forAssettoCorsa = false)
         {
 
             int lastSectorPlayerCompleted = playerSessionData.SectorNumber == 1 ? 3 : playerSessionData.SectorNumber - 1;
@@ -638,11 +638,11 @@ namespace CrewChiefV4.GameState
                 return null;
             }
             float timeDifference;
-            if (Position == playerSessionData.Position + 1) 
+            if (Position == playerSessionData.Position + 1 && !forAssettoCorsa) 
             {
                 timeDifference = -1 * playerSessionData.TimeDeltaBehind;
             }
-            else if (Position == playerSessionData.Position - 1)
+            else if (Position == playerSessionData.Position - 1 && !forAssettoCorsa)
             {
                 timeDifference = playerSessionData.TimeDeltaFront;
             }

--- a/CrewChiefV4/TrackData.cs
+++ b/CrewChiefV4/TrackData.cs
@@ -170,7 +170,8 @@ namespace CrewChiefV4
         public float[] pitExitPoint = new float[] { 0, 0 };
         public float[] gapPoints = new float[] { };
         public float pitEntryExitPointsDiameter = 3;   // if we're within this many metres of the pit entry point, we're entering the pit
-
+        public int sectorsOnTrack = 3;
+        public float[] sectorPoints = new float[] { 0, 0 };
         public TrackDefinition(String name, float pitEntryExitPointsDiameter, float trackLength, float[] pitEntryPoint, float[] pitExitPoint)
         {
             this.name = name;
@@ -186,6 +187,15 @@ namespace CrewChiefV4
             this.name = name;
             this.trackLength = trackLength;
             this.hasPitLane = false;
+        }
+
+        public TrackDefinition(String name, float trackLength, int sectorsOnTrack, float[] sectorPoints)
+        {
+            this.name = name;
+            this.trackLength = trackLength;
+            this.hasPitLane = true;
+            this.sectorsOnTrack = sectorsOnTrack;
+            this.sectorPoints = sectorPoints;
         }
 
         public void setGapPoints()
@@ -214,6 +224,17 @@ namespace CrewChiefV4
 
                 gapPoints = gaps.ToArray();
             }
+        }
+
+        void setSectorPointsForUnknownTracks()
+        {
+            if (sectorsOnTrack == 0)
+            {
+                sectorsOnTrack = 1;
+            }
+            float sectorSpacing = trackLength / sectorsOnTrack;
+            sectorPoints[0] = sectorSpacing;
+            sectorPoints[1] = sectorSpacing * 2;
         }
 
         public Boolean isAtPitEntry(float x, float y)


### PR DESCRIPTION
* Fixed a timing issue related to previousGameState not getting get, and added laptiming

* Basic opponent data added should update correctly when a new player joins server, and added more varibles to sharedmem.

* Added sector and lap time to opponents and fixed some int float varible mixup.

* Opponent remove fix

* Latest update better session tracking for multiplayer, sector times added aswell

* Clean up as requested

* Cleaned up python for release

* Added user option to set car length for spotter in acs

* Removed some not needed as they are invalid. and optimized python some more.

* Found a small bug related to position.

* Optimized so not needed data for spotter does not get processed unless needed for GameStateData

* Spotter code optimized as much as i could,SPageFilePhysics is needed for yaw :(

* Added fuel levels, cut track, engine rpm and pit exit warnings

* raceposition should fixed in qual and practice.

* Added a default parameter to getTimeDifferenceToPlayer, to compnsate for AC's lack of data.

* More AC additions and fixes