### PR TITLE
Call Dispose on temporary Joystick objects because the finalizer does…

### DIFF
--- a/CrewChiefV4/ControllerConfiguration.cs
+++ b/CrewChiefV4/ControllerConfiguration.cs
@@ -73,6 +73,7 @@ namespace CrewChiefV4
             catch (Exception)
             {
             }
+            joystick.Dispose();
             controllers.Add(new ControllerData(productName, DeviceType.Joystick, guid));
         }
 
@@ -314,6 +315,7 @@ namespace CrewChiefV4
                         {
 
                         }
+                        joystick.Dispose();
                         controllers.Add(new ControllerData(productName, deviceType, joystickGuid));
                     }
                 }

--- a/CrewChiefV4/Properties/AssemblyInfo.cs
+++ b/CrewChiefV4/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.4.2.3")]
+[assembly: AssemblyVersion("4.4.2.4")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CrewChiefV4_no_sound_files/CrewChiefV4_setup_project.isl
+++ b/CrewChiefV4_no_sound_files/CrewChiefV4_setup_project.isl
@@ -4399,9 +4399,9 @@ RABWAEQALQA1AAEARQB4AHAAcgBlAHMAcwA=
 		<row><td>PROGMSG_IIS_ROLLBACKVROOTS</td><td>##IDS_PROGMSG_IIS_ROLLBACKVROOTS##</td><td/></row>
 		<row><td>PROGMSG_IIS_ROLLBACKWEBSERVICEEXTENSIONS</td><td>##IDS_PROGMSG_IIS_ROLLBACKWEBSERVICEEXTENSIONS##</td><td/></row>
 		<row><td>PROGRAMFILETOLAUNCHATEND</td><td>[INSTALLDIR]CrewChiefV4.Primary output</td><td/></row>
-		<row><td>ProductCode</td><td>{8F483E4F-2034-4541-9785-7ED78DF1273E}</td><td/></row>
+		<row><td>ProductCode</td><td>{13EB0463-E85F-475E-AEB0-663F2431B6AC}</td><td/></row>
 		<row><td>ProductName</td><td>CrewChiefV4</td><td/></row>
-		<row><td>ProductVersion</td><td>4.4.2.3</td><td/></row>
+		<row><td>ProductVersion</td><td>4.4.2.4</td><td/></row>
 		<row><td>ProgressType0</td><td>install</td><td/></row>
 		<row><td>ProgressType1</td><td>Installing</td><td/></row>
 		<row><td>ProgressType2</td><td>installed</td><td/></row>

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,9 @@ CrewChief version 4.
 
 Changelog
 ---------
-Version 4.4.2.2: Removed some debug calls
+Version 4.4.2.4: Fixed controllers initialisation bug which should fix very slow (2-3 minutes) startup time for some users - thanks Tako.
+
+Version 4.4.2.3: Removed some debug calls
 
 Version 4.4.2.2: Only cancel pre-lights messages on throttle application; Added option to disable yellow flags in Assetto Corsa, and made them a little less frequent; Some Assetto Corsa opponent position fixes
 

--- a/auto_update_data.xml
+++ b/auto_update_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <item>
-<title>Crew Chief 4.4.2.3, updated 06 Nov 2016</title>
-<version>4.4.2.3</version>
+<title>Crew Chief 4.4.2.4, updated 08 Nov 2016</title>
+<version>4.4.2.4</version>
 <url>http://crewchief.isnais.de/CrewChiefV4.msi</url>
 <changelog>http://crewchief.isnais.de/change_log_for_auto_updated.html</changelog>
 

--- a/change_log_for_auto_updated.html
+++ b/change_log_for_auto_updated.html
@@ -1,6 +1,10 @@
 <!DOCTYPE html>
 <html>
 <body>
+<h2>Version 4.4.2.4</h2>
+<ul>
+	<li>Fixed controllers initialisation bug which should fix very slow (2-3 minutes) startup time for some users - thanks Tako</li>
+</ul>
 <h2>Version 4.4.2.3</h2>
 <ul>
 	<li>Removed some debug calls</li>


### PR DESCRIPTION
…n't appear to do it properly; 4.4.2.4 build stuff